### PR TITLE
Fix stop-bitcoin-stats

### DIFF
--- a/data/bitcoin.js
+++ b/data/bitcoin.js
@@ -193,7 +193,7 @@ function BitcoinSetup(scope) {
   });
 
   EventBus.$on('stop-bitcoin-stats', () => {
-    IntervalBus.clear(populate.connectons);
+    IntervalBus.clear(populate.connections);
   });
 
   EventBus.$on('load-bitcoin-transactions', (options = {autoupdate: true}) => {

--- a/data/bitcoin.js
+++ b/data/bitcoin.js
@@ -193,6 +193,7 @@ function BitcoinSetup(scope) {
   });
 
   EventBus.$on('stop-bitcoin-stats', () => {
+    IntervalBus.clear(populate.addresses);
     IntervalBus.clear(populate.connections);
   });
 


### PR DESCRIPTION
Typo in clearing populate.connections.
Missing clear for populate.addresses. 